### PR TITLE
Fixed: Exit Button Fail Example 1

### DIFF
--- a/gooi/gooi.lua
+++ b/gooi/gooi.lua
@@ -2325,7 +2325,7 @@ function gooi.checkBounds(text, x, y, w, h, t)
 end
 
 function gooi.getFont(comp)
-    if comp and comp.style.font then
+    if comp and comp.style and comp.style.font then
         return comp.style.font
     end
     return gooi.font or gooi.defaultFont


### PR DESCRIPTION
    Error: gooi/gooi.lua:2328: attempt to index field 'style' (a nil value)
            stack traceback:
            gooi/gooi.lua:2328: in function 'getFont'
            gooi/gooi.lua:1993: in function 'draw'

    modified:   gooi.lua